### PR TITLE
Add an Internal storage button to the file dialogs

### DIFF
--- a/src/osdep/generic_target.cpp
+++ b/src/osdep/generic_target.cpp
@@ -411,6 +411,39 @@ void removeFileExtension(char *filename)
 }
 
 
+#ifdef ANDROID
+// The file dialogs open inside the private app directory, and its parent
+// /storage/emulated/0/Android/data cannot be opened since Android 11, so
+// walking up with ".." dead ends there and drops back to the start path.
+// Give the dialogs a way to jump straight to the storage root instead.
+const char *GetInternalStoragePath(void)
+{
+  static char path[MAX_DPATH];
+  const char *candidates[3];
+  int i;
+
+  candidates[0] = getenv("EXTERNAL_STORAGE");
+  candidates[1] = "/storage/emulated/0";
+  candidates[2] = "/sdcard";
+
+  for(i = 0; i < 3; ++i)
+  {
+    DIR *dir;
+    if(candidates[i] == NULL || candidates[i][0] == '\0')
+      continue;
+    dir = opendir(candidates[i]);
+    if(dir == NULL)
+      continue;
+    closedir(dir);
+    strncpy(path, candidates[i], MAX_DPATH - 1);
+    path[MAX_DPATH - 1] = '\0';
+    return path;
+  }
+  return NULL;
+}
+#endif
+
+
 void ReadDirectory(const char *path, std::vector<std::string> *dirs, std::vector<std::string> *files)
 {
   DIR *dir;

--- a/src/osdep/gui/SelectFile.cpp
+++ b/src/osdep/gui/SelectFile.cpp
@@ -45,6 +45,11 @@ static gcn::ScrollArea* scrAreaFiles;
 static gcn::TextField *txtCurrent;
 static gcn::Label *lblFilename;
 static gcn::TextField *txtFilename;
+#ifdef ANDROID
+static gcn::Button* cmdStorage;
+#endif
+
+static void checkfoldername (char *current);
 
 
 class SelectFileListModel : public gcn::ListModel
@@ -93,6 +98,20 @@ class FileButtonActionListener : public gcn::ActionListener
   public:
     void action(const gcn::ActionEvent& actionEvent)
     {
+#ifdef ANDROID
+      if (actionEvent.getSource() == cmdStorage)
+      {
+        const char *root = GetInternalStoragePath();
+        if(root != NULL)
+        {
+          char tmp[MAX_PATH];
+          strncpy(tmp, root, MAX_PATH - 1);
+          tmp[MAX_PATH - 1] = '\0';
+          checkfoldername(tmp);
+        }
+        return; // Keep the dialog open, we only moved to another directory
+      }
+#endif
       if (actionEvent.getSource() == cmdOK)
       {
         int selected_item;
@@ -222,6 +241,14 @@ static void InitSelectFile(const char *title)
   cmdCancel->setBaseColor(gui_baseCol + 0x202020);
   cmdCancel->addActionListener(fileButtonActionListener);
 
+#ifdef ANDROID
+  cmdStorage = new gcn::Button("Internal storage");
+  cmdStorage->setSize(BUTTON_WIDTH * 2, BUTTON_HEIGHT);
+  cmdStorage->setPosition(DISTANCE_BORDER, DIALOG_HEIGHT - 2 * DISTANCE_BORDER - BUTTON_HEIGHT - 10);
+  cmdStorage->setBaseColor(gui_baseCol + 0x202020);
+  cmdStorage->addActionListener(fileButtonActionListener);
+#endif
+
   txtCurrent = new gcn::TextField();
   txtCurrent->setSize(DIALOG_WIDTH - 2 * DISTANCE_BORDER - 4, TEXTFIELD_HEIGHT);
   txtCurrent->setPosition(DISTANCE_BORDER, 10);
@@ -275,6 +302,9 @@ static void InitSelectFile(const char *title)
   
   wndSelectFile->add(cmdOK);
   wndSelectFile->add(cmdCancel);
+#ifdef ANDROID
+  wndSelectFile->add(cmdStorage);
+#endif
   wndSelectFile->add(txtCurrent);
   wndSelectFile->add(scrAreaFiles);
   
@@ -293,6 +323,9 @@ static void ExitSelectFile(void)
 
   delete cmdOK;
   delete cmdCancel;
+#ifdef ANDROID
+  delete cmdStorage;
+#endif
   delete fileButtonActionListener;
   
   delete txtCurrent;

--- a/src/osdep/gui/SelectFolder.cpp
+++ b/src/osdep/gui/SelectFolder.cpp
@@ -38,6 +38,11 @@ static gcn::Button* cmdCancel;
 static gcn::ListBox* lstFolders;
 static gcn::ScrollArea* scrAreaFolders;
 static gcn::TextField *txtCurrent;
+#ifdef ANDROID
+static gcn::Button* cmdStorage;
+#endif
+
+static void checkfoldername (char *current);
 
 
 class ButtonActionListener : public gcn::ActionListener
@@ -45,6 +50,18 @@ class ButtonActionListener : public gcn::ActionListener
   public:
     void action(const gcn::ActionEvent& actionEvent)
     {
+#ifdef ANDROID
+      if (actionEvent.getSource() == cmdStorage) {
+        const char *root = GetInternalStoragePath();
+        if(root != NULL) {
+          char tmp[MAX_PATH];
+          strncpy(tmp, root, MAX_PATH - 1);
+          tmp[MAX_PATH - 1] = '\0';
+          checkfoldername(tmp);
+        }
+        return; // Keep the dialog open, we only moved to another directory
+      }
+#endif
       if (actionEvent.getSource() == cmdOK) {
         dialogResult = true;
       }
@@ -158,6 +175,14 @@ static void InitSelectFolder(const char *title)
   cmdCancel->setBaseColor(gui_baseCol + 0x202020);
   cmdCancel->addActionListener(buttonActionListener);
 
+#ifdef ANDROID
+  cmdStorage = new gcn::Button("Internal storage");
+  cmdStorage->setSize(BUTTON_WIDTH * 2, BUTTON_HEIGHT);
+  cmdStorage->setPosition(DISTANCE_BORDER, DIALOG_HEIGHT - 2 * DISTANCE_BORDER - BUTTON_HEIGHT - 10);
+  cmdStorage->setBaseColor(gui_baseCol + 0x202020);
+  cmdStorage->addActionListener(buttonActionListener);
+#endif
+
   txtCurrent = new gcn::TextField();
   txtCurrent->setSize(DIALOG_WIDTH - 2 * DISTANCE_BORDER - 4, TEXTFIELD_HEIGHT);
   txtCurrent->setPosition(DISTANCE_BORDER, 10);
@@ -194,6 +219,9 @@ static void InitSelectFolder(const char *title)
   
   wndSelectFolder->add(cmdOK);
   wndSelectFolder->add(cmdCancel);
+#ifdef ANDROID
+  wndSelectFolder->add(cmdStorage);
+#endif
   wndSelectFolder->add(txtCurrent);
   wndSelectFolder->add(scrAreaFolders);
   
@@ -212,8 +240,11 @@ static void ExitSelectFolder(void)
 
   delete cmdOK;
   delete cmdCancel;
+#ifdef ANDROID
+  delete cmdStorage;
+#endif
   delete buttonActionListener;
-  
+
   delete txtCurrent;
   delete lstFolders;
   delete scrAreaFolders;
@@ -252,8 +283,15 @@ static void SelectFolderLoop(void)
                 cmdCancel->requestFocus();
               else if(activeWidget == cmdCancel)
                 cmdOK->requestFocus();
+#ifdef ANDROID
+              else if(activeWidget == cmdOK)
+                cmdStorage->requestFocus();
+              else if(activeWidget == cmdStorage)
+                lstFolders->requestFocus();
+#else
               else if(activeWidget == cmdOK)
                 lstFolders->requestFocus();
+#endif
               continue;
             }
             break;
@@ -262,8 +300,15 @@ static void SelectFolderLoop(void)
             {
               gcn::FocusHandler* focusHdl = gui_top->_getFocusHandler();
               gcn::Widget* activeWidget = focusHdl->getFocused();
+#ifdef ANDROID
+              if(activeWidget == lstFolders)
+                cmdStorage->requestFocus();
+              else if(activeWidget == cmdStorage)
+                cmdOK->requestFocus();
+#else
               if(activeWidget == lstFolders)
                 cmdOK->requestFocus();
+#endif
               else if(activeWidget == cmdCancel)
                 lstFolders->requestFocus();
               else if(activeWidget == cmdOK)

--- a/src/osdep/gui/gui_handling.h
+++ b/src/osdep/gui/gui_handling.h
@@ -152,6 +152,9 @@ ConfigFileInfo* SearchConfigInList(const char *name);
 
 extern void ReadDirectory(const char *path, std::vector<std::string> *dirs, std::vector<std::string> *files);
 extern void FilterFiles(std::vector<std::string> *files, const char *filter[]);
+#ifdef ANDROID
+extern const char *GetInternalStoragePath(void);
+#endif
 
 enum { DIRECTION_NONE, DIRECTION_UP, DIRECTION_DOWN, DIRECTION_LEFT, DIRECTION_RIGHT };
 bool HandleNavigation(int direction);


### PR DESCRIPTION
The dialogs open inside the private app directory, and since Android 11 its parent /storage/emulated/0/Android/data cannot be opened at all. Walking up with ".." therefore fails: checkfoldername() cannot opendir() the parent, silently falls back to the start path, and the dialog appears to refuse to go up. The only way out was to tap the path field and delete the extra path components with the virtual keyboard.

Add a button that jumps straight to the storage root, skipping the unreadable directory in between. The path is probed at runtime, trying EXTERNAL_STORAGE first and then the usual mount points, so devices that map it elsewhere keep working.

Android only, the desktop and Pandora builds are untouched.